### PR TITLE
Fix api error: DeepL API仕様変更への対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/issues/
 sandbox/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/issues/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/issues/
+sandbox/

--- a/paralellTranslationGenerator.py
+++ b/paralellTranslationGenerator.py
@@ -27,14 +27,27 @@ def en2jp_deepl(translate_text):
     if DEEPL_KEY:
         params = {
             "auth_key": DEEPL_KEY,
-            "text": translate_text,
+            "text": [translate_text],
             "source_lang": 'EN',
             "target_lang": 'JA'
         }
 
-        request = requests.post("https://api-free.deepl.com/v2/translate", data=params)
+        request = requests.post("https://api-free.deepl.com/v2/translate", json=params)
         result = request.json()
-        return result["translations"][0]["text"]
+        
+        # APIレスポンスのデバッグ出力（デバッグ時のみ有効化）
+        # st.write("API Response:", result)
+        
+        # エラーハンドリングを追加
+        if "translations" in result:
+            return result["translations"][0]["text"]
+        elif "error" in result:
+            error_msg = f"DeepL API Error: {result['error'].get('message', 'Unknown error')}"
+            st.error(error_msg)
+            return ""
+        else:
+            st.error(f"Unexpected API response format: {result}")
+            return ""
     else:
         st.warning("Please enter the DeepL API Key in the sidebar.")
         return ""


### PR DESCRIPTION
## 概要
DeepL APIの仕様変更に対応するための修正を行いました。現在のコードでは、APIからのレスポンスに`translations`キーが存在しないため、KeyErrorが発生していました。検証の結果、APIの仕様が変更され、リクエストパラメータの送信方法と形式を変更する必要があることが判明しました。

## 変更内容
1. `text`パラメータを文字列の配列として送信するように変更
2. リクエストの送信方法を`data=params`から`json=params`に変更
3. エラーハンドリングを追加して、APIからのエラーレスポンスを適切に処理

## 検証結果
検証ツールを作成・実行し、以下の点が明らかになりました：

1. DeepL APIの仕様変更：
   - `text`パラメータが文字列の配列として送信する必要がある
   - リクエストの送信方法が`data=params`ではなく`json=params`を使用する必要がある

2. 修正後の動作確認：
   - すべてのテストケースで正常にAPIからのレスポンスを受け取ることができた
   - 大文字小文字の区別なし、`source_lang`パラメータの省略可能性なども確認

## 変更されたファイル
1. `paralellTranslationGenerator.py`
   - `en2jp_deepl`関数の修正
   - リクエストパラメータとリクエスト送信方法の変更
   - エラーハンドリングの追加

## 新規作成されたファイル
1. `sandbox/deepl_api_test.py`
   - Streamlitベースの検証ツール
   - ユーザーインターフェースを通じてAPIの動作を検証

2. `sandbox/deepl_api_direct_test.py`
   - コマンドラインベースの検証ツール
   - 様々なパラメータでのAPIテスト

3. `docs/issues/issue2.md`
   - 検証結果と解決策の詳細な記録

## 修正前後のコード比較

### 修正前
```python
def en2jp_deepl(translate_text):
    if DEEPL_KEY:
        params = {
            "auth_key": DEEPL_KEY,
            "text": translate_text,
            "source_lang": 'EN',
            "target_lang": 'JA'
        }

        request = requests.post("https://api-free.deepl.com/v2/translate", data=params)
        result = request.json()
        return result["translations"][0]["text"]
    else:
        st.warning("Please enter the DeepL API Key in the sidebar.")
        return ""
```

### 修正後
```python
def en2jp_deepl(translate_text):
    if DEEPL_KEY:
        params = {
            "auth_key": DEEPL_KEY,
            "text": [translate_text],  # textを配列として送信
            "source_lang": 'EN',
            "target_lang": 'JA'
        }

        request = requests.post("https://api-free.deepl.com/v2/translate", json=params)  # data=paramsではなくjson=paramsを使用
        result = request.json()
        
        # エラーハンドリングを追加
        if "translations" in result:
            return result["translations"][0]["text"]
        elif "error" in result:
            error_msg = f"DeepL API Error: {result['error'].get('message', 'Unknown error')}"
            st.error(error_msg)
            return ""
        else:
            st.error(f"Unexpected API response format: {result}")
            return ""
    else:
        st.warning("Please enter the DeepL API Key in the sidebar.")
        return ""
```

## テスト方法
1. DeepL APIキーを入力して翻訳機能を使用
2. 検証ツール（`sandbox/deepl_api_test.py`または`sandbox/deepl_api_direct_test.py`）を実行して、APIの動作を確認

## 今後の改善点
1. ユーザーフレンドリーなエラーメッセージの表示
2. リトライメカニズムの実装
3. オフライン対応の検討
4. APIキーの検証機能の追加
5. APIの仕様変更への対応策の検討

## レビュー依頼事項
- エラーハンドリングの方法は適切か
- APIの仕様変更に対する対応方法は適切か
- 今後の改善点として挙げた項目は妥当か